### PR TITLE
feat: add minimal prediction market api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -93,8 +93,11 @@ cd prediction-market
 # Install dependencies
 npm install
 
-# Start development server
-npm run dev
+# Start the API server
+npm start
+
+# In another terminal, fetch markets
+curl http://localhost:3000/markets
 ```
 
 To deploy contracts:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "prediction-market",
+  "version": "0.1.0",
+  "description": "Minimal Prediction Market API",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node -e \"console.log('No tests yet')\""
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "body-parser": "^1.20.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,51 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+
+const app = express();
+app.use(bodyParser.json());
+
+// In-memory market storage
+const markets = [
+  {
+    market_id: '1',
+    question: 'Will SpaceX land humans on Mars before 2030?',
+    outcomes: ['Yes', 'No'],
+    liquidity_pool: {
+      yes_price: 0.45,
+      no_price: 0.55
+    },
+    volume: 0,
+    status: 'open'
+  }
+];
+
+app.get('/', (req, res) => {
+  res.send('Prediction Market API');
+});
+
+app.get('/markets', (req, res) => {
+  res.json(markets);
+});
+
+app.post('/markets', (req, res) => {
+  const { question, outcomes } = req.body;
+  if (!question || !Array.isArray(outcomes) || outcomes.length < 2) {
+    return res.status(400).json({ error: 'Invalid market data' });
+  }
+
+  const newMarket = {
+    market_id: (markets.length + 1).toString(),
+    question,
+    outcomes,
+    liquidity_pool: {},
+    volume: 0,
+    status: 'open'
+  };
+  markets.push(newMarket);
+  res.status(201).json(newMarket);
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add minimal Express server exposing market endpoints
- document setup and usage in README
- configure package metadata and ignore node modules

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/body-parser)*
- `npm test`
- `npm start` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_b_68c62079e3c08329811001278248bd72