### PR TITLE
Add static frontend prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ npm install
 npm run dev
 ```
 
+### Static Frontend Prototype
+
+For a quick preview of the user interface, simply open `index.html` in your browser. This static page lists example markets and demonstrates basic styling.
+
 To deploy contracts:
 
 ```bash

--- a/app.js
+++ b/app.js
@@ -1,0 +1,46 @@
+const markets = [
+  {
+    question: 'Will SpaceX land humans on Mars before 2030?',
+    yesPrice: 0.45,
+    noPrice: 0.55,
+    volume: 12345.67
+  },
+  {
+    question: 'Will Bitcoin close above $100k in 2025?',
+    yesPrice: 0.32,
+    noPrice: 0.68,
+    volume: 98765.43
+  },
+  {
+    question: 'Will proposal #123 pass in the DAO?',
+    yesPrice: 0.7,
+    noPrice: 0.3,
+    volume: 4321.0
+  }
+];
+
+function renderMarkets() {
+  const list = document.getElementById('market-list');
+  markets.forEach(market => {
+    const card = document.createElement('div');
+    card.className = 'market-card';
+
+    const title = document.createElement('h2');
+    title.textContent = market.question;
+    card.appendChild(title);
+
+    const prices = document.createElement('div');
+    prices.className = 'prices';
+    prices.innerHTML = `<span>Yes: ${market.yesPrice}</span><span>No: ${market.noPrice}</span>`;
+    card.appendChild(prices);
+
+    const volume = document.createElement('div');
+    volume.className = 'volume';
+    volume.textContent = `Volume: ${market.volume}`;
+    card.appendChild(volume);
+
+    list.appendChild(card);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', renderMarkets);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Prediction Market</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Prediction Market</h1>
+  </header>
+  <main>
+    <section id="market-list"></section>
+  </main>
+  <footer>
+    <p>Powered by decentralized forecasts.</p>
+  </footer>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,57 @@
+:root {
+  --primary: #2b6cb0;
+  --bg: #f7fafc;
+  --text: #2d3748;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  margin: 0;
+}
+
+header {
+  background: var(--primary);
+  color: #fff;
+  padding: 1rem;
+  text-align: center;
+}
+
+#market-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.market-card {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  padding: 1rem;
+}
+
+.market-card h2 {
+  font-size: 1.1rem;
+  margin-top: 0;
+}
+
+.market-card .prices {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.5rem;
+}
+
+.market-card .volume {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  color: #4a5568;
+}
+
+footer {
+  text-align: center;
+  padding: 1rem;
+  font-size: 0.9rem;
+  color: #718096;
+}


### PR DESCRIPTION
## Summary
- add minimal index.html with dynamic market listing
- style front-end with responsive CSS
- render sample markets via JavaScript
- document prototype usage in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c6220e14f48329bef71955ea2a6f0e